### PR TITLE
Return empty string when there is no CONTENT_TYPE

### DIFF
--- a/graphene_file_upload/__init__.py
+++ b/graphene_file_upload/__init__.py
@@ -17,7 +17,7 @@ class ModifiedGraphQLView(GraphQLView):
 
     @staticmethod
     def get_graphql_params(request, data):
-        request_type = request.META.get("CONTENT_TYPE")
+        request_type = request.META.get("CONTENT_TYPE", '')
 
         if "multipart/form-data" in request_type:
             query, variables, operation_name, id = super(ModifiedGraphQLView, ModifiedGraphQLView).get_graphql_params(request, data)


### PR DESCRIPTION
This PR fixes the case when the request META doesn't contain the `content type` variable, e.g `graphiql` over `uwsgi`.
