### PR TITLE
explicitly specify packages to remove shadow trap

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,14 +79,15 @@ pip install -r requirements-tox.txt
 # depending on your system.
 
 # Run the test suite with the versions of python you have installed
-tox -e py27,py34
+tox -e py27,py34 --develop
 # Alternatively, if you're using something like pyenv and can easily install
 # Multiple versions of python, then try running the following command
-tox
+tox --develop
 
 # If for some reason you need to recreate the tox environment (e.g. a new
-# dependency has been added since you last ran it, add the -r flag to the
-# tox command)
+# dependency has been added since you last ran it, you run `tox` without the
+# `--develop` flag), add the -r flag to the tox command
+
 tox -r {...additional flags...}
 ```
 

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
         'graphene_file_upload.flask',
         'graphene_file_upload.django',
     ],
-    version='1.1.0',
+    version='1.2.0',
     description='Lib for adding file upload functionality to GraphQL mutations in Graphene Django and Flask-Graphql',
     long_description=long_description,
     long_description_content_type='text/x-rst',

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,11 @@ tests_require = flask_requires + django_requires + [
 
 setup(
     name='graphene_file_upload',
-    packages=['graphene_file_upload'], # this must be the same as the name above
+    packages=[
+        'graphene_file_upload', # this must be the same as the name above
+        'graphene_file_upload.flask',
+        'graphene_file_upload.django',
+    ],
     version='1.1.0',
     description='Lib for adding file upload functionality to GraphQL mutations in Graphene Django and Flask-Graphql',
     long_description=long_description,

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,6 @@
 envlist = py27, py34, py35, py36, py37
 
 [testenv]
-usedevelop = True
 deps =
     .[test]
 commands =


### PR DESCRIPTION
Resolves #21.

The shadowing trap was fixed for editable dependencies, but distribution removed the package hierarchy and led back to the name shadowing trap for python2. I've experimented with removing `-e` from local installs and this seems to be working appropriately.

One way to quickly verify this change is to compare the following:

* Change `-e ../../` to just `../../` in `requirements.txt` for the flask example
* Create a python2 virtualenv and pip install the requirements
* Confirm that the shadowing trap breaks the app on `master`
* Scrap the old virtualenv, create a new one, and run the past 3 steps on this new branch.

You can also inspect `venv/lib/python2.7/site-packages/graphene_file_upload` to confirm that on master they're distributed as flat `flask.py` and `django.py` files and on this branch they're distributed as `flask/__init__.py` and `django/__init__.py` files.