### PR TITLE
Support for Uploads when using Django Form

### DIFF
--- a/graphene_file_upload/django/__init__.py
+++ b/graphene_file_upload/django/__init__.py
@@ -1,8 +1,16 @@
 """Apply multipart request spec to django"""
 import json
+from django.forms import FileField
 from graphene_django.views import GraphQLView
+from graphene_django.forms.converter import convert_form_field
 
 from ..utils import place_files_in_operations
+from ..scalars import Upload
+
+
+@convert_form_field.register(FileField)
+def convert_form_field_to_upload(field):
+    return Upload(description=field.help_text, required=field.required)
 
 
 class FileUploadGraphQLView(GraphQLView):

--- a/graphene_file_upload/django/mutation.py
+++ b/graphene_file_upload/django/mutation.py
@@ -1,0 +1,126 @@
+from collections import OrderedDict
+from django.forms import FileField
+import graphene
+from graphene import Field, InputField
+from graphene.types.utils import yank_fields_from_attrs
+from graphene_django.registry import get_global_registry
+from graphene_django.forms.converter import convert_form_field
+from graphene_django.forms.types import ErrorType
+from graphene_django.forms.mutation import BaseDjangoFormMutation, DjangoModelDjangoFormMutationOptions
+
+
+def fields_for_form(form, only_fields, exclude_fields):
+    fields = OrderedDict()
+    file_fields = []
+    for name, field in form.fields.items():
+        is_not_in_only = only_fields and name not in only_fields
+        is_excluded = (
+            name
+            in exclude_fields  # or
+            # name in already_created_fields
+        )
+
+        if is_not_in_only or is_excluded:
+            continue
+
+        if isinstance(field, FileField):
+            file_fields.append(name)
+
+        fields[name] = convert_form_field(field)
+    return (fields, file_fields)
+
+
+class DjangoUploadModelDjangoFormMutationOptions(DjangoModelDjangoFormMutationOptions):
+    file_fields = None  # type: array
+
+
+class BaseDjangoUploadFormMutation(BaseDjangoFormMutation):
+    class Meta:
+        abstract = True
+
+    @classmethod
+    def get_form(cls, root, info, **input):
+        form_kwargs = {}
+        pk = input.pop("id", None)
+        if pk:
+            instance = cls._meta.model._default_manager.get(pk=pk)
+            form_kwargs["instance"] = instance
+
+        files_dict = OrderedDict()
+        for v in cls._meta.file_fields:
+            files_dict[v] = input.pop(v)
+        return cls._meta.form_class(input, files_dict, **form_kwargs)
+
+    @classmethod
+    def get_form_kwargs(cls, root, info, **input):
+        kwargs = {"data": input}
+
+        pk = input.pop("id", None)
+        if pk:
+            instance = cls._meta.model._default_manager.get(pk=pk)
+            kwargs["instance"] = instance
+
+        return kwargs
+
+
+class DjangoUploadModelFormMutation(BaseDjangoUploadFormMutation):
+    class Meta:
+        abstract = True
+
+    errors = graphene.List(ErrorType)
+
+    @classmethod
+    def __init_subclass_with_meta__(
+        cls,
+        form_class=None,
+        model=None,
+        return_field_name=None,
+        only_fields=(),
+        exclude_fields=(),
+        **options
+    ):
+
+        if not form_class:
+            raise Exception(
+                "form_class is required for DjangoModelFormMutation")
+
+        if not model:
+            model = form_class._meta.model
+
+        if not model:
+            raise Exception("model is required for DjangoModelFormMutation")
+
+        form = form_class()
+        (input_fields, file_fields) = fields_for_form(
+            form, only_fields, exclude_fields)
+        if "id" not in exclude_fields:
+            input_fields["id"] = graphene.ID()
+
+        registry = get_global_registry()
+        model_type = registry.get_type_for_model(model)
+        return_field_name = return_field_name
+        if not return_field_name:
+            model_name = model.__name__
+            return_field_name = model_name[:1].lower() + model_name[1:]
+
+        output_fields = OrderedDict()
+        output_fields[return_field_name] = graphene.Field(model_type)
+
+        _meta = DjangoUploadModelDjangoFormMutationOptions(cls)
+        _meta.form_class = form_class
+        _meta.model = model
+        _meta.return_field_name = return_field_name
+        _meta.fields = yank_fields_from_attrs(output_fields, _as=Field)
+        _meta.file_fields = file_fields
+
+        input_fields = yank_fields_from_attrs(input_fields, _as=InputField)
+
+        super(DjangoUploadModelFormMutation, cls).__init_subclass_with_meta__(
+            _meta=_meta, input_fields=input_fields, **options
+        )
+
+    @classmethod
+    def perform_mutate(cls, form, info):
+        obj = form.save()
+        kwargs = {cls._meta.return_field_name: obj}
+        return cls(errors=[], **kwargs)


### PR DESCRIPTION
This is a Work In Progress PR w/ preliminary source code to show what I am trying to achieve and would like a feedback before I move forward with this idea.

## Problem

Django Forms work in a different way when it comes to uploads. The uploads must be sent in the second argument of the Form constructor. The `FILES` object is typically a dictionary where the keys match the field names. If you send the file object key in the first argument, the file is ignored from the form:

```
some_form = SomeModelForm(request.POST, request.FILES)
```

However, the Apollo Upload specification handles uploads in a different way. Firstly, the `request.FILES` object becomes an ordered dictionary of values such as ```{ "0": MemoryUploadedFilehandler(...) }```. Secondly, as far as I understood from specs and the source code, the "map" field helps the server to merge the uploaded files into a single field (as array or just one object). This works great when dealing files right inside of GraphQL/Graphene mutations. However, the way Django Forms and this library handles files is not aligned.

## Solution

I have decided to play with this idea (when I started with this idea, I was not aware of graphene-file-upload library but this example code will work regardless) and came up with a solution. I have written the source code that works with Django's ModelForm and I tried to make sure that the way the mutation classes are implemented are similar in architecture to Graphene Django's mutations. I have copied some things from Graphene Django docs to scaffold my idea because it was not possible to properly extend Graphene Django's model to only add the necessary logic; however, I want to refactor it to extend instead of replace these classes.

In the source code below, I am doing two things:

First and foremost, I am registering Django Form's FileField (ImageField is derived from FileField; so, mapping one field is enough) class to accept `Upload` type. This is because, by default FileField accepts only Strings and we will get an error (`__init__.py` line 11-13). I put this register in `__init__.py`; so that, the types are mapped as soon as you import the view custom GraphQL view.

Then, I created a custom class `DjangoUploadModelFormMutation` that works exactly like `DjangoModelFormMutation` but tries to extract fields that are instances of `FileField` and store it in an array. Before Django Form is created for validation, the stored file field names are used to extract files from the input object. The extracted values are then sent as a second argument to Django Form (mutation.py line 50-53). I had to rewrite that part because Graphene Django uses keyword arguments to pass form data but I have failed to find a way to pass files as keyword arguments as well. So, I had to override `get_form` method instead of overriding `get_form_kwargs` method.

## Usage

When doing it this way, the usage becomes much easier because the developer does not need to write anything other than change the class name:

```

class PersonForm(ModelForm):
   ...
   photo = ImageField(upload_to='images/')

class CreatePersonMutation(DjangoUploadModelFormMutation): # Just replace the class name 
    class Meta:
        form_class = PersonForm
        exclude_fields = ('id',)
```

Of course this usage would be different for non Model Form but I think it is possible to make it as seamless as possible for existing codebases; so that, devs can work with validated form data instead of mutation inputs.

## Things to do

- [ ] Write models for Django Form (not ModelForm)
- [ ] Refactor ModelForm to properly extend from Graphene Django mutations
- [ ] Write tests
- [ ] Write docs showing usage with Django Forms

---

If you would like this integration to be part of the library, I am willing to help with this.