### PR TITLE
Exclude 'tests' from the package list

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ all_requires = flask_requires + django_requires
 
 setup(
     name='graphene_file_upload',
-    packages=find_packages(),
+    packages=find_packages(exclude=["tests"]),
     version='1.2.2',
     description='Lib for adding file upload functionality to GraphQL mutations in Graphene Django and Flask-Graphql',
     long_description=long_description,


### PR DESCRIPTION
As noted in #41, the 'tests' directory is falsely added to the list of packages. This pull request excludes the tests directory from that list.