### PR TITLE
Fix error with coverage command

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,6 @@ deps =
     pytest-cov
     py3{4,5,6,7,8,9}: pylint
 commands =
-    -coverage clean
+    -coverage erase
     py3{4,5,6,7,8,9}: pylint graphene_file_upload
     py.test --cov=graphene_file_upload -v tests/


### PR DESCRIPTION
Resolves

```bash
Unknown command: 'clean'
Use 'coverage help' for help.
```

For more information
```
coverage help
Coverage.py, version 5.3.1 with C extension
Measure, collect, and report on code coverage in Python programs.

usage: coverage <command> [options] [args]

Commands:
    annotate    Annotate source files with execution information.
    combine     Combine a number of data files.
    debug       Display information about the internals of coverage.py
    erase       Erase previously collected coverage data.
    help        Get help on using coverage.py.
    html        Create an HTML report.
    json        Create a JSON report of coverage results.
    report      Report coverage stats on modules.
    run         Run a Python program and measure code execution.
    xml         Create an XML report of coverage results.

Use "coverage help <command>" for detailed help on any command.
Full documentation is at https://coverage.readthedocs.io
```

@lmcgartland 