### PR TITLE
Generalize testing.file_graphql_query

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ import tempfile
 
 from flaskr import flaskr
 import pytest
-from graphene_file_upload.django.testing import file_graphql_query
+from graphene_file_upload.flask.testing import file_graphql_query
 
 
 @pytest.fixture

--- a/graphene_file_upload/flask/testing.py
+++ b/graphene_file_upload/flask/testing.py
@@ -1,5 +1,4 @@
-"""Use django's Test client to run file based graphql test."""
-from django.test import Client, TestCase
+"""Use flask's Test client to run file based graphql test."""
 from .. import testingbase
 
 DEFAULT_GRAPHQL_URL = "/graphql/"
@@ -12,9 +11,9 @@ def create_client_post(client):
     def client_post(graphql_url, data, files, headers=None):
         data.update(files)
         if headers:
-            response = client.post(graphql_url, data, headers=headers)
+            response = client.post(graphql_url, data=data, headers=headers)
         else:
-            response = client.post(graphql_url, data)
+            response = client.post(graphql_url, data=data)
         return response
     return client_post
 
@@ -38,16 +37,10 @@ def file_graphql_query(
     :param dict headers: If provided, the headers in POST request to GRAPHQL_URL
         will be set to this value. Defaults to None
     :param dict files: Files to be sent via request.FILES. Defaults to None.
-    :param django.test.Client client: Test client. Defaults to django.test.Client.
+    :param  flask.testing.FlaskClient: Test client. Defaults to None.
     :param str graphql_url: URL to graphql endpoint. Defaults to "/graphql"
     :return: Response object from client
     """
-    client = client or Client()
     client_post = create_client_post(client)
     return testingbase.file_graphql_query(
         query, op_name, input_data, variables, headers, files, client_post, graphql_url)
-
-
-class GraphQLFileUploadTestCase(testingbase.GraphQLFileUploadTestMixin, TestCase):
-    def setUp(self) -> None:
-        self.client_post = create_client_post(self.client)

--- a/graphene_file_upload/testingbase.py
+++ b/graphene_file_upload/testingbase.py
@@ -1,0 +1,134 @@
+"""Base of using Test client to run file based graphql test."""
+import json
+DEFAULT_GRAPHQL_URL = "/graphql/"
+
+
+def file_graphql_query(
+        query, op_name=None, input_data=None, variables=None,
+        headers=None, files=None, client_post=None, graphql_url=None,
+):
+    """
+    Based on: https://www.sam.today/blog/testing-graphql-with-graphene-django/
+
+    Perform file based mutation.
+
+    :param str query: GraphQL query to run
+    :param str op_name: If the query is a mutation or named query, you must
+        supply the op_name. For annon queries ("{ ... }"), should be None (default).
+    :param dict input_data: If provided, the $input variable in GraphQL will be set
+        to this value. If both ``input_data`` and ``variables``,
+        are provided, the ``input`` field in the ``variables``
+        dict will be overwritten with this value. Defaults to None.
+    :param dict variables: If provided, the "variables" field in GraphQL will be
+        set to this value. Defaults to None.
+    :param dict headers: If provided, the headers in POST request to GRAPHQL_URL
+        will be set to this value. Defaults to None
+    :param dict files: Files to be sent via request.FILES. Defaults to None.
+    :param callable client_post: Test client wrapper function.
+                It receives graphql endpoint(str), data(dict), files(dict), headers(dict).
+                When called, it sends POST request using framework specific test client.
+                Defaults to None.
+    :param str graphql_url: URL to graphql endpoint. Defaults to "/graphql"
+    :return: Response object from client
+    """
+
+    if not files:
+        raise ValueError('Missing required argument "files".')
+
+    if not client_post:
+        raise ValueError('Missing required argument "client_post".')
+
+    headers = headers or {}
+    variables = variables or {}
+    graphql_url = graphql_url or DEFAULT_GRAPHQL_URL
+    map_ = {}
+
+    for key in files.keys():
+        map_[key] = [f'variables.{key}']
+        if key not in variables:
+            variables[key] = None
+
+    body = {'query': query}
+    if op_name:
+        body['operationName'] = op_name
+    if variables:
+        body['variables'] = variables
+    if input_data:
+        if 'variables' in body:
+            body['variables']['input'] = input_data
+        else:
+            body['variables'] = {'input': input_data}
+
+    data = {
+        'operations': json.dumps(body),
+        'map': json.dumps(map_),
+    }
+
+    # data.update(files)
+    if headers:
+        resp = client_post(graphql_url, data, files ** headers)
+    else:
+        resp = client_post(graphql_url, data, files)
+
+    return resp
+
+
+class GraphQLFileUploadTestMixin:
+    """GraphQL file upload test mixin."""
+
+    # URL to graphql endpoint
+    GRAPHQL_URL = DEFAULT_GRAPHQL_URL
+
+    def file_query(
+            self, query, op_name=None, input_data=None, files=None,
+            variables=None, headers=None,
+    ):
+        """
+        Perform file based mutation.
+        :param str query: GraphQL query to run
+        :param str op_name: If the query is a mutation or named query, you must
+            supply the op_name. For annon queries ("{ ... }"), should be None (default).
+        :param dict input_data: If provided, the $input variable in GraphQL will be set
+            to this value. If both ``input_data`` and ``variables``,
+            are provided, the ``input`` field in the ``variables``
+            dict will be overwritten with this value. Defaults to None.
+        :param dict variables: If provided, the "variables" field in GraphQL will be
+            set to this value. Defaults to None.
+        :param dict headers: If provided, the headers in POST request to GRAPHQL_URL
+            will be set to this value. Defaults to None
+        :param dict files: Files to be sent via request.FILES. Defaults to None.
+        :param django.test.Client client: Test client. Defaults to django.test.Client.
+        :param str graphql_url: URL to graphql endpoint. Defaults to "/graphql"
+        :return: Response object from client
+        """
+        return file_graphql_query(
+            query,
+            op_name=op_name,
+            input_data=input_data,
+            variables=variables,
+            headers=headers,
+            files=files,
+            client_post=self.client_post,
+            graphql_url=self.GRAPHQL_URL,
+        )
+
+    def assertResponseNoErrors(self, resp, msg=None):  # pylint: disable=C0103
+        """
+        Assert that the call went through correctly. 200 means the syntax is ok,
+        if there are no `errors`, the call was fine.
+        :param Response resp: HttpResponse
+        :param str msg: Error message.
+        """
+        content = json.loads(resp.content)
+        self.assertEqual(resp.status_code, 200, msg or content)
+        self.assertNotIn("errors", list(content.keys()), msg or content)
+
+    def assertResponseHasErrors(self, resp, msg=None):  # pylint: disable=C0103
+        """
+        Assert that the call was failing. Take care: Even with errors,
+        GraphQL returns status 200!
+        :param Response resp: HttpResponse
+        :param str msg: Error message.
+        """
+        content = json.loads(resp.content)
+        self.assertIn("errors", list(content.keys()), msg or content)

--- a/tests/test_flask.py
+++ b/tests/test_flask.py
@@ -6,6 +6,8 @@ import pytest
 from .flask_app import create_app
 from .schema import schema
 
+from graphene_file_upload.flask.testing import file_graphql_query
+
 
 def response_utf8_json(resp):
     return json.loads(resp.data.decode())
@@ -53,6 +55,48 @@ def test_single_file(client, file_text, expected_first_line):
                     't_file': ['variables.file'],
                 }),
             }
+        )
+    assert response.status_code == 200
+    assert response_utf8_json(response) == {
+        'data': {
+            'myUpload': {
+                'ok': True,
+                'firstLine': expected_first_line,
+            },
+        }
+    }
+
+
+@pytest.mark.parametrize(
+    'client,file_text,expected_first_line',
+    (
+        (None, u'Fake Data\nLine2\n', u'Fake Data'),
+        # Try the fire emoji
+        (None, u'\U0001F525\nLine2\nLine3\n', u'\U0001F525'),
+    ),
+    indirect=['client']
+)
+def test_file_graphql_query(client, file_text, expected_first_line):
+
+    query = '''
+        mutation testMutation($file: Upload!) {
+            myUpload(fileIn: $file) {
+                ok
+                firstLine
+            }
+        }
+    '''
+
+    with NamedTemporaryFile() as t_file:
+        t_file.write(file_text.encode('utf-8'))
+        t_file.seek(0)
+
+        response = file_graphql_query(
+            query,
+            op_name='testMutation',
+            files={'file': t_file},
+            client=client,
+            graphql_url='/graphql',
         )
     assert response.status_code == 200
     assert response_utf8_json(response) == {


### PR DESCRIPTION
# Generalized django.testing.file_graphql_query to other frameworks than Django

## Background

Although graphene_file_upload.django.testing.file_graphql_query is imported in the example of testing for flask, as metioned in issue #59  , file_graphql_query depends on Django for using django.testing.Client as default argument.
However, it seems almost all codes in file_graphql_query are not specialized for Django. The only point tightly coupled with Django is the argument structure of django.testing.Client.post method.
Test client of other frameworks, such as flask.testing.FlaskClient or fastapi.testclinet.TestClient, also has post method, but their argument is slightly different from Django's one.
Examples of differences are below.
- In Django data is a positional argument but in Flask data is a keyword argument.
- In Django and Flask, files should be contain data argument, but in FastApi files is separated argument (Not client.post("/graphql", data=data) but client.post("/graphql", data=data, files=files) works)
It would be useful to modify file_graphql_query to be able to absorb framework's test client differences.

## Implements

All logics in file_graphql_query which are not coupled with Django ara moved into, testingbase.py, and client argument is changed into client_post argument. client_post argument is a function that abstracts post method of each frameworks' test client post methods. It receives endpoint, data, files, and headers.
And testing.py for each frameworks(in /graphene_file_upload/django/testing and /graphene_file_upload/flask/testing) implements client_post using framework specific test client. I only implemented for only Django and Flask, but testingbase.file_graphql_query can be applicable for any other frameworks such as FastAPI.